### PR TITLE
Add spaces between literals and identifiers

### DIFF
--- a/bf2c.cc
+++ b/bf2c.cc
@@ -57,7 +57,7 @@ int main(int argc, char *argv[]) {
 	pt = NULL;
 	infname = outfname = invchar = NULL;
 
-	printf("bf2c.cc "VERSION" Copyright (c) 2002-"ENDYEAR" Rene Ladan <r.c.ladan@gmail.com>\n\n"
+	printf("bf2c.cc " VERSION " Copyright (c) 2002-" ENDYEAR " Rene Ladan <r.c.ladan@gmail.com>\n\n"
 		"Optimizing BrainFuck to C compiler.\n\n");
 
 	while ((opt = getopt(argc,argv,"i:o:hs:r:")) != -1) {


### PR DESCRIPTION
Adds spaces between literals and identifiers. This is required in C++11 mode, which newer compilers default to. Without this change, the build fails with Clang 8, for example:

```
/opt/local/bin/clang++-mp-8.0 -Os -stdlib=libc++ -arch x86_64   -c -o bf2c.o bf2c.cc
bf2c.cc:60:19: error: invalid suffix on literal; C++11 requires a space between literal and identifier [-Wreserved-user-defined-literal]
        printf("bf2c.cc "VERSION" Copyright (c) 2002-"ENDYEAR" Rene Ladan <r.c.ladan@gmail.com>\n\n"
                         ^

bf2c.cc:60:48: error: invalid suffix on literal; C++11 requires a space between literal and identifier [-Wreserved-user-defined-literal]
        printf("bf2c.cc "VERSION" Copyright (c) 2002-"ENDYEAR" Rene Ladan <r.c.ladan@gmail.com>\n\n"
                                                      ^

2 errors generated.
```
